### PR TITLE
Added code to handle T3460 timer as part of stateless MME

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
@@ -1087,6 +1087,8 @@ static void _authentication_t3460_handler(void* args) {
       emm_sap_send(&emm_sap);
       emm_common_cleanup_by_ueid(ue_id);
 
+      emm_ctx_clear_nas_procedures_timer_mask(
+          emm_ctx, NAS_AUTH_PROCEDUE_3460_TIMER);
       // abort ANY ongoing EMM procedure (R10_5_4_2_7_b)
       nas_delete_all_emm_procedures(emm_ctx);
 

--- a/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
@@ -752,6 +752,8 @@ static int _security_request(nas_emm_smc_proc_t* const smc_proc) {
       nas_start_T3460(
           smc_proc->ue_id, &smc_proc->T3460,
           smc_proc->emm_com_proc.emm_proc.base_proc.time_out, emm_ctx);
+      emm_ctx_set_nas_procedures_timer_mask(
+          emm_ctx, NAS_SMC_PROCEDUE_3460_TIMER);
     }
   }
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);

--- a/lte/gateway/c/oai/tasks/nas/emm/emm_data.h
+++ b/lte/gateway/c/oai/tasks/nas/emm/emm_data.h
@@ -361,6 +361,13 @@ typedef struct emm_context_s {
    *if this flag is set after receving service req, send detach
    */
   bool nw_init_bearer_deactv;
+#define NAS_PROC_AUTHENTICATION 0x01
+#define NAS_PROC_SECURITY_MODE 0x02
+#define NAS_AUTH_PROCEDUE_3460_TIMER ((uint32_t) 1 << 0)
+#define NAS_SMC_PROCEDUE_3460_TIMER ((uint32_t) 1 << 1)
+#define IS_NAS_AUTH_PROCEDUE_3460_TIMER_RUNNING                                \
+  (nas_procedures_timer_mask & NAS_AUTH_PROCEDUE_3460_TIMER)
+  uint32_t nas_procedures_timer_mask;
 } emm_context_t;
 
 /*
@@ -552,7 +559,12 @@ void emm_context_free_content_except_key_fields(
 void emm_context_dump(
     const struct emm_context_s* const elm_pP, const uint8_t indent_spaces,
     bstring bstr_dump) __attribute__((nonnull));
-
+void emm_ctx_set_nas_procedures_timer_mask(
+    emm_context_t* const ctxt, const int nas_proc_bit_pos)
+    __attribute__((nonnull)) __attribute__((flatten));
+void emm_ctx_clear_nas_procedures_timer_mask(
+    emm_context_t* const ctxt, const int nas_proc_bit_pos)
+    __attribute__((nonnull)) __attribute__((flatten));
 /****************************************************************************/
 /********************  G L O B A L    V A R I A B L E S  ********************/
 /****************************************************************************/

--- a/lte/protos/oai/nas_state.proto
+++ b/lte/protos/oai/nas_state.proto
@@ -416,5 +416,6 @@ message EmmContext {
   uint32 ksi = 64;
 
   UeNetworkCapability ue_network_capability = 65;
+  uint32 nas_procedures_timer_mask = 66;
   // TODO: add remaining emm_context elements
   }


### PR DESCRIPTION
Signed-off-by: rashmi <rashmi.sarwad@radisys.com>

Added code to handle T3460 timer as part of stateless MME


